### PR TITLE
new: `insert_adj_top_level_fn`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           matrix:
             parameters:
               db-mode: ["single", "cluster"]
-              db-version: ["3.10", "3.11", "3.12"]
+              db-version: ["3.10", "3.11", "3.12.2"]
 
 jobs:
   lint-python:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phenolrs"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "arangors-graph-exporter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phenolrs"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "phenolrs"
-version = "0.5.8"
+version = "0.5.9"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/phenolrs/__init__.py
+++ b/python/phenolrs/__init__.py
@@ -1,6 +1,5 @@
 from .phenolrs import *  # noqa: F403
 
-
 __doc__ = phenolrs.__doc__  # type: ignore[name-defined]  # noqa: F405
 if hasattr(phenolrs, "__all__"):  # type: ignore[name-defined]  # noqa: F405
     __all__ = phenolrs.__all__  # type: ignore[name-defined]  # noqa: F405

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,6 +4,7 @@ import arango
 import networkx as nx
 import pytest
 from adbnx_adapter import ADBNX_Adapter
+from arango.database import StandardDatabase
 from arango_datasets import Datasets
 
 connection_config: Dict[str, Any]
@@ -34,9 +35,7 @@ def connection_information() -> Dict[str, Any]:
     }
 
 
-def load_dataset(
-    dataset: str, db_name: str, connection_information: Dict[str, Any]
-) -> None:
+def get_db(db_name: str, connection_information: Dict[str, Any]) -> StandardDatabase:
     client = arango.ArangoClient(connection_information["url"])
     sys_db = client.db(
         "_system",
@@ -46,28 +45,61 @@ def load_dataset(
 
     if not sys_db.has_database(db_name):
         sys_db.create_database(db_name)
-        db = client.db(
-            db_name,
-            username=connection_information["username"],
-            password=connection_information["password"],
-        )
-        dsets = Datasets(db)
-        dsets.load(dataset)
+
+    return client.db(
+        db_name,
+        username=connection_information["username"],
+        password=connection_information["password"],
+    )
 
 
 @pytest.fixture(scope="module")
 def load_abide(abide_db_name: str, connection_information: Dict[str, Any]) -> None:
-    load_dataset("ABIDE", abide_db_name, connection_information)
+    db = get_db(abide_db_name, connection_information)
+
+    if not db.has_graph("ABIDE"):
+        Datasets(db).load("ABIDE")
 
 
 @pytest.fixture(scope="module")
 def load_imdb(imdb_db_name: str, connection_information: Dict[str, Any]) -> None:
-    load_dataset("IMDB_PLATFORM", imdb_db_name, connection_information)
+    db = get_db(imdb_db_name, connection_information)
+
+    if not db.has_graph("IMDB_PLATFORM"):
+        Datasets(db).load("IMDB_PLATFORM")
 
 
 @pytest.fixture(scope="module")
 def load_dblp(dblp_db_name: str, connection_information: Dict[str, Any]) -> None:
-    load_dataset("DBLP", dblp_db_name, connection_information)
+    db = get_db(dblp_db_name, connection_information)
+
+    if not db.has_graph("DBLP"):
+        Datasets(db).load("DBLP")
+
+
+@pytest.fixture(scope="module")
+def load_isolated_node(
+    isolated_node_db_name: str, connection_information: Dict[str, Any]
+) -> None:
+    db = get_db(isolated_node_db_name, connection_information)
+
+    if not db.has_graph("ISOLATED_NODE"):
+        db.create_graph(
+            "ISOLATED_NODE",
+            edge_definitions=[
+                {
+                    "edge_collection": "edge",
+                    "from_vertex_collections": ["node"],
+                    "to_vertex_collections": ["node"],
+                }
+            ],
+        )
+
+        db.collection("node").insert({"_key": "0"})
+        db.collection("node").insert({"_key": "1"})
+        db.collection("node").insert({"_key": "2"})  # isolated node
+
+        db.collection("edge").insert({"_from": "node/0", "_to": "node/1"})
 
 
 @pytest.fixture(scope="module")
@@ -83,6 +115,11 @@ def imdb_db_name() -> str:
 @pytest.fixture(scope="module")
 def dblp_db_name() -> str:
     return "dblp"
+
+
+@pytest.fixture(scope="module")
+def isolated_node_db_name() -> str:
+    return "isolated_node"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/test_all.py
+++ b/python/tests/test_all.py
@@ -870,3 +870,86 @@ def test_imdb_networkx(
                     for key, value in edge.items():
                         assert isinstance(key, str)
                         assert value is not None
+
+
+def test_isolated_node_networkx(
+    load_isolated_node: None,
+    isolated_node_db_name: str,
+    connection_information: dict[str, str],
+) -> None:
+    metagraph = {
+        "vertexCollections": {"node": set()},
+        "edgeCollections": {"edge": set()},
+    }
+
+    node_dict, adj_dict, *_ = NetworkXLoader.load_into_networkx(
+        isolated_node_db_name,
+        metagraph,
+        [connection_information["url"]],
+        username=connection_information["username"],
+        password=connection_information["password"],
+        is_directed=False,
+        is_multigraph=False,
+    )
+
+    assert len(node_dict) == 3
+    assert len(adj_dict) == 3
+    assert len(adj_dict["node/0"]) == 1
+    assert len(adj_dict["node/1"]) == 1
+    assert len(adj_dict["node/2"]) == 0
+
+    node_dict, adj_dict, *_ = NetworkXLoader.load_into_networkx(
+        isolated_node_db_name,
+        metagraph,
+        [connection_information["url"]],
+        username=connection_information["username"],
+        password=connection_information["password"],
+        is_directed=True,
+        is_multigraph=False,
+    )
+
+    assert len(node_dict) == 3
+    assert len(adj_dict["succ"]) == 3
+    assert len(adj_dict["pred"]) == 3
+    assert len(adj_dict["succ"]["node/0"]) == 1
+    assert len(adj_dict["succ"]["node/1"]) == 0
+    assert len(adj_dict["succ"]["node/2"]) == 0
+    assert len(adj_dict["pred"]["node/0"]) == 0
+    assert len(adj_dict["pred"]["node/1"]) == 1
+    assert len(adj_dict["pred"]["node/2"]) == 0
+
+    node_dict, adj_dict, *_ = NetworkXLoader.load_into_networkx(
+        isolated_node_db_name,
+        metagraph,
+        [connection_information["url"]],
+        username=connection_information["username"],
+        password=connection_information["password"],
+        is_directed=False,
+        is_multigraph=True,
+    )
+
+    assert len(node_dict) == 3
+    assert len(adj_dict) == 3
+    assert len(adj_dict["node/0"]) == 1
+    assert len(adj_dict["node/1"]) == 1
+    assert len(adj_dict["node/2"]) == 0
+
+    node_dict, adj_dict, *_ = NetworkXLoader.load_into_networkx(
+        isolated_node_db_name,
+        metagraph,
+        [connection_information["url"]],
+        username=connection_information["username"],
+        password=connection_information["password"],
+        is_directed=True,
+        is_multigraph=True,
+    )
+
+    assert len(node_dict) == 3
+    assert len(adj_dict["succ"]) == 3
+    assert len(adj_dict["pred"]) == 3
+    assert len(adj_dict["succ"]["node/0"]) == 1
+    assert len(adj_dict["succ"]["node/1"]) == 0
+    assert len(adj_dict["succ"]["node/2"]) == 0
+    assert len(adj_dict["pred"]["node/0"]) == 0
+    assert len(adj_dict["pred"]["node/1"]) == 1
+    assert len(adj_dict["pred"]["node/2"]) == 0

--- a/python/tests/test_all.py
+++ b/python/tests/test_all.py
@@ -877,7 +877,7 @@ def test_isolated_node_networkx(
     isolated_node_db_name: str,
     connection_information: dict[str, str],
 ) -> None:
-    metagraph = {
+    metagraph: dict[str, Any] = {
         "vertexCollections": {"node": set()},
         "edgeCollections": {"edge": set()},
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -86,6 +86,7 @@ pub struct NetworkXGraph {
         fn(&mut NetworkXGraph, String, String, Vec<Value>, &Vec<String>) -> Map<String, Value>,
     insert_coo_fn: fn(&mut NetworkXGraph, String, String, HashMap<String, f64>),
     insert_adj_fn: fn(&mut NetworkXGraph, String, String, Map<String, Value>),
+    insert_adj_top_level_fn: fn(&mut NetworkXGraph, String),
     insert_edge_fn: fn(&mut NetworkXGraph, String, String, Vec<Value>, &Vec<String>) -> Result<()>,
 }
 
@@ -166,6 +167,20 @@ impl NetworkXGraph {
             }
         };
 
+        let insert_adj_top_level_fn = if is_multigraph {
+            if is_directed {
+                NetworkXGraph::insert_adj_multidigraph_top_level
+            } else {
+                NetworkXGraph::insert_adj_multigraph_top_level
+            }
+        } else {
+            if is_directed {
+                NetworkXGraph::insert_adj_digraph_top_level
+            } else {
+                NetworkXGraph::insert_adj_graph_top_level
+            }
+        };
+
         let insert_edge_fn = if load_coo && load_adj_dict {
             NetworkXGraph::insert_edge_as_coo_and_adj
         } else if load_coo {
@@ -190,6 +205,7 @@ impl NetworkXGraph {
             get_edge_properties_fn,
             insert_coo_fn,
             insert_adj_fn,
+            insert_adj_top_level_fn,
             insert_edge_fn,
         }))
     }
@@ -426,14 +442,8 @@ impl NetworkXGraph {
         to_id_str: String,
         properties: Map<String, Value>,
     ) {
-        if !self.adj_map_graph.contains_key(&from_id_str) {
-            self.adj_map_graph
-                .insert(from_id_str.clone(), HashMap::new());
-        }
-
-        if !self.adj_map_graph.contains_key(&to_id_str) {
-            self.adj_map_graph.insert(to_id_str.clone(), HashMap::new());
-        }
+        self.insert_adj_graph_top_level(from_id_str.clone());
+        self.insert_adj_graph_top_level(to_id_str.clone());
 
         let from_map = self.adj_map_graph.get_mut(&from_id_str).unwrap();
         panic_if_edge_exists(from_map, from_id_str.clone(), to_id_str.clone());
@@ -447,6 +457,12 @@ impl NetworkXGraph {
         to_map.insert(from_id_str, properties);
     }
 
+    fn insert_adj_graph_top_level(&mut self, id_str: String) {
+        if !self.adj_map_graph.contains_key(&id_str) {
+            self.adj_map_graph.insert(id_str.clone(), HashMap::new());
+        }
+    }
+
     fn insert_adj_digraph(
         &mut self,
         from_id_str: String,
@@ -454,15 +470,9 @@ impl NetworkXGraph {
         properties: Map<String, Value>,
     ) {
         // 1) Add [from, to] in _succ adjacency list
+        self.insert_adj_digraph_top_level(from_id_str.clone());
+
         let _succ = self.adj_map_digraph.get_mut("succ").unwrap();
-
-        if !_succ.contains_key(&from_id_str) {
-            _succ.insert(from_id_str.clone(), HashMap::new());
-        }
-
-        if !_succ.contains_key(&to_id_str) {
-            _succ.insert(to_id_str.clone(), HashMap::new());
-        }
 
         let succ_from_map = _succ.get_mut(&from_id_str).unwrap();
         panic_if_edge_exists(succ_from_map, from_id_str.clone(), to_id_str.clone());
@@ -477,6 +487,8 @@ impl NetworkXGraph {
         }
 
         // 2) Add [to, from] in _pred adjacency list
+        self.insert_adj_digraph_top_level(to_id_str.clone());
+
         let _pred = self.adj_map_digraph.get_mut("pred").unwrap();
 
         if !_pred.contains_key(&to_id_str) {
@@ -500,21 +512,28 @@ impl NetworkXGraph {
         }
     }
 
+    fn insert_adj_digraph_top_level(&mut self, id_str: String) {
+        let _succ = self.adj_map_digraph.get_mut("succ").unwrap();
+
+        if !_succ.contains_key(&id_str) {
+            _succ.insert(id_str.clone(), HashMap::new());
+        }
+
+        let _pred = self.adj_map_digraph.get_mut("pred").unwrap();
+
+        if !_pred.contains_key(&id_str) {
+            _pred.insert(id_str.clone(), HashMap::new());
+        }
+    }
+
     fn insert_adj_multigraph(
         &mut self,
         from_id_str: String,
         to_id_str: String,
         properties: Map<String, Value>,
     ) {
-        if !self.adj_map_multigraph.contains_key(&from_id_str) {
-            self.adj_map_multigraph
-                .insert(from_id_str.clone(), HashMap::new());
-        }
-
-        if !self.adj_map_multigraph.contains_key(&to_id_str) {
-            self.adj_map_multigraph
-                .insert(to_id_str.clone(), HashMap::new());
-        }
+        self.insert_adj_multigraph_top_level(from_id_str.clone());
+        self.insert_adj_multigraph_top_level(to_id_str.clone());
 
         let from_map = self.adj_map_multigraph.get_mut(&from_id_str).unwrap();
         let from_to_map = from_map.entry(to_id_str.clone()).or_default();
@@ -526,6 +545,13 @@ impl NetworkXGraph {
         to_from_map.insert(index, properties);
     }
 
+    fn insert_adj_multigraph_top_level(&mut self, id_str: String) {
+        if !self.adj_map_multigraph.contains_key(&id_str) {
+            self.adj_map_multigraph
+                .insert(id_str.clone(), HashMap::new());
+        }
+    }
+
     fn insert_adj_multidigraph(
         &mut self,
         from_id_str: String,
@@ -533,7 +559,10 @@ impl NetworkXGraph {
         properties: Map<String, Value>,
     ) {
         // 1) Add [from, to] in _succ adjacency list
-        let _succ = self.adj_map_multidigraph.get_mut("succ").unwrap();
+        self.insert_adj_multidigraph_top_level(from_id_str.clone());
+
+        let _succ: &mut HashMap<String, HashMap<String, HashMap<usize, Map<String, Value>>>> =
+            self.adj_map_multidigraph.get_mut("succ").unwrap();
 
         if !_succ.contains_key(&from_id_str) {
             _succ.insert(from_id_str.clone(), HashMap::new());
@@ -555,6 +584,8 @@ impl NetworkXGraph {
         }
 
         // 2) Add [to, from] in _pred adjacency list
+        self.insert_adj_multidigraph_top_level(to_id_str.clone());
+
         let _pred = self.adj_map_multidigraph.get_mut("pred").unwrap();
 
         if !_pred.contains_key(&to_id_str) {
@@ -575,6 +606,20 @@ impl NetworkXGraph {
             let pred_from_map = _pred.get_mut(&from_id_str).unwrap();
             let pred_from_to_map = pred_from_map.entry(to_id_str).or_default();
             pred_from_to_map.insert(index, properties);
+        }
+    }
+
+    fn insert_adj_multidigraph_top_level(&mut self, id_str: String) {
+        let _succ = self.adj_map_multidigraph.get_mut("succ").unwrap();
+
+        if !_succ.contains_key(&id_str) {
+            _succ.insert(id_str.clone(), HashMap::new());
+        }
+
+        let _pred = self.adj_map_multidigraph.get_mut("pred").unwrap();
+
+        if !_pred.contains_key(&id_str) {
+            _pred.insert(id_str.clone(), HashMap::new());
         }
     }
 
@@ -852,7 +897,8 @@ impl Graph for NetworkXGraph {
         let properties =
             (self.get_vertex_properties_fn)(self, vertex_id.clone(), columns, field_names);
 
-        self.node_map.insert(vertex_id, properties.clone());
+        self.node_map.insert(vertex_id.clone(), properties.clone());
+        (self.insert_adj_top_level_fn)(self, vertex_id);
     }
 
     fn insert_edge(


### PR DESCRIPTION
- Introducing `insert_adj_top_level_fn` as a function responsible for inserting a NetworkX Node ID into the Adjacency Object, regardless of Graph Type. 
- `insert_adj_top_level_fn` is now newly invoked in `insert_vertex()`, to prevent Isolated Nodes from being excluded in the Adjacency Object

Note: `3.12` CI will fail due to known issue with `3.12.3`, which will be fixed in `3.12.4`