### PR TITLE
Ais 1273 graphml make phenolrs pyG hetero loader resilient to extra vertex features fix for ais 1088

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phenolrs"
-version = "0.5.12"
+version = "0.5.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "phenolrs"
-version = "0.5.12"
+version = "0.5.13"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/phenolrs/pyg/loader.py
+++ b/python/phenolrs/pyg/loader.py
@@ -156,6 +156,8 @@ class PygLoader:
             for feature in features_by_col[col].keys():
                 if feature == "@collection_name":
                     continue
+                if feature not in col_mapping:
+                    continue
 
                 target_name = col_mapping[feature]
                 result = torch.from_numpy(


### PR DESCRIPTION
## Summary

GraphML: Make phenolrs PyG hetero loader resilient to extra vertex features (fix for AIS-1087)

## Changes

### phenolrs (`python/phenolrs/pyg/loader.py`)

* In `load_into_pyg_heterodata()`, skip features not present in the per-collection metagraph mapping instead of raising `KeyError`.
* Added condition:

  ```python
  if feature not in col_mapping:
      continue
  ```

## Release

* Bumped version and cut a new release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.5.13

* **Bug Fixes**
  * Enhanced data loader to gracefully skip missing feature mappings instead of causing errors during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->